### PR TITLE
Improve widget argument detection in lint rule.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hardcoded_strings_lint
 description: A custom Flutter lint rule that identifies and prevents hardcoded strings in widget constructors, promoting better internationalization practices and code maintainability.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/ShahSomething
 repository: https://github.com/ShahSomething/hardcoded_strings_lint
 issue_tracker: https://github.com/ShahSomething/hardcoded_strings_lint/issues


### PR DESCRIPTION
Refines the logic for detecting hardcoded strings passed to widget constructors, ensuring strings inside callback or function bodies are not incorrectly flagged. Bumps package version to 1.0.4.

For example: while using logger inside BlocListener, I was getting lint issue as the listener is defined inside some build method. This will handle the case. 